### PR TITLE
5 distorsion param for plumb_bob model because aruco_detect wants them

### DIFF
--- a/src/gazebo_ros_realsense.cpp
+++ b/src/gazebo_ros_realsense.cpp
@@ -263,6 +263,12 @@ sensor_msgs::CameraInfo cameraInfo(const sensor_msgs::Image &image,
   info_msg.K[5] = info_msg.height * 0.5;
   info_msg.K[8] = 1.;
 
+  info_msg.D.push_back(0);
+  info_msg.D.push_back(0);
+  info_msg.D.push_back(0);
+  info_msg.D.push_back(0);
+  info_msg.D.push_back(0);
+
   info_msg.P[0] = info_msg.K[0];
   info_msg.P[5] = info_msg.K[4];
   info_msg.P[2] = info_msg.K[2];


### PR DESCRIPTION
I filled the array of camera msg with zeros (I checked and also the real camera data is [0,0,0,0,0])
Having this field empty make the [aruco_detect](https://github.com/UbiquityRobotics/fiducials) node to crash:

https://github.com/UbiquityRobotics/fiducials/blob/1ae8a13d56fafa436aca181da451c1bf808a288c/aruco_detect/src/aruco_detect.cpp#L320-L322